### PR TITLE
Startup: Add "Bookmarks" policy for managing the bookmark list

### DIFF
--- a/esr60/Startup
+++ b/esr60/Startup
@@ -70,6 +70,21 @@ Startup-5: 初期状態のブックマーク
     lockPref("browser.bookmarks.autoExportHTML", false);
     defaultPref("browser.bookmarks.restore_default_bookmarks", false);
 
+    :3: 管理者が指定したブックマークを追加する
+
+    // ブックマークのアップデートは起動ごとに行われる。
+    // JSONの定義から削除したサイトは次回起動時に自動的に削除される。
+    "Bookmarks": [
+      {
+        "Title": "Clear Code",
+        "URL": "http://www.clear-code.com",
+        "Favicon": "http://www.clear-code.com/favicon.ico",
+        "Placement": "toolbar",
+        "Folder": "Company"
+      }
+    ]
+
+
 Startup-6: [廃止] 「あなたの権利」の表示の可否
 
     :1: [廃止] 許可する（既定）


### PR DESCRIPTION
管理者が所定のサイトをブックマークを追加できるようにする機能です。

* ポリシーはスタートアップごとに行われます。なので、ユーザーがブックマークをクリアしても
  定義にあるウェブサイトは次回起動時に復活します。

* この機能は単純に一覧に追加するだけのものなので、ユーザーの追加するものについては
  管轄外のようです（特定の状態でブックマークを固定できるわけではない）。
