### PR TITLE
Fix offer for windows 11 21H2

### DIFF
--- a/verify/terraform/windows-11-21H2/main.tf
+++ b/verify/terraform/windows-11-21H2/main.tf
@@ -66,7 +66,7 @@ resource "azurerm_virtual_machine" "firefoxverify_vm" {
   storage_image_reference {
     # Windows 11 Pro 21H2
     publisher = "MicrosoftWindowsDesktop"
-    offer     = "windows11preview"
+    offer     = "Windows-11"
     sku       = "win11-21h2-pro"
     version   = "latest"
   }


### PR DESCRIPTION
No need to use preview.

   ╷
   │ Error: compute.VirtualMachinesClient#CreateOrUpdate: Failure sending request: StatusCode=404 -- Original Error: Code="PlatformImageNotFound" Message="The platform image 'MicrosoftWindowsDesktop:windows11preview:win11-21h2-pro:latest' is not available. Verify that all fields in the storage profile are correct. For more details about storage profile information, please refer to https://aka.ms/storageprofile" Target="imageReference"
   │
   │   with azurerm_virtual_machine.firefoxverify_vm,
   │   on main.tf line 57, in resource "azurerm_virtual_machine" "firefoxverify_vm":
   │   57: resource "azurerm_virtual_machine" "firefoxverify_vm" {

