### PR TITLE
Fix migration report markdown

### DIFF
--- a/migration/esr115.md
+++ b/migration/esr115.md
@@ -258,7 +258,7 @@ Firefox ESR102のサポートは、2023年9月26日で終了します（以後�
 
 * [HTMLの`<menuitem>`要素の対応を廃止。](https://bugzil.la/1372276)（Firefox 103）
   <!-- - この挙動は設定で無効化できません。 -->
-* [MathMLの`scrptminsize`および`scriptsizemultiplier`属性の対応を廃止。](https://bugzil.la/1772697)（Firefox 103）
+* [MathMLの`scriptminsize`および`scriptsizemultiplier`属性の対応を廃止。](https://bugzil.la/1772697)（Firefox 103）
   <!-- - この挙動は設定で無効化できません。 -->
 * [`IDBFactory.open()`](https://developer.mozilla.org/en-US/docs/Web/API/IDBFactory/open)の[非標準のオプションであった`options`引数への対応を廃止](https://bugzil.la/1354500)（代わりに[`StorageManager.persist()`](https://developer.mozilla.org/en-US/docs/Web/API/StorageManager/persist)を使うことを推奨）。（Firefox 104）
   <!-- - この挙動は設定で無効化できません。 -->

--- a/migration/esr115.md
+++ b/migration/esr115.md
@@ -84,7 +84,7 @@ Firefox ESR102のサポートは、2023年9月26日で終了します（以後�
   * この変更は可逆的で、`alerts.useSystemBackend`を`false`にすることで従来の動作に戻せます。
 * アドレスバーからWeb検索を実行した際の検索結果のページを表示している間、検索サービスのURLではなく、入力した検索語句をアドレスバーに表示できるようになった。（Firefox 113）  
   ![](esr115/addressbar-show-search-terms.png){ width=400px }
-  * 本稿執筆時点では、この機能は初期状態では無効のため挙動は変化しません。ただし、Firefox ESR115正式版では初期状態で有効になる可能性はあります。
+  * 既定の状態では機能無効の隠し設定となっているため挙動は変化しません。
   * `browser.urlbar.showSearchTerms.featureGate`が`true`の時にのみ機能及び設定UIが有効化されます。  
     ![](esr115/addressbar-show-search-terms-setting.png){ width=400px }
   * この変更は可逆的で、`browser.urlbar.showSearchTerms.enabled`を`false`にすることで従来の動作に戻せます。


### PR DESCRIPTION
Two revisions: 
* a typo 
* description that became incorrect 