### PR TITLE
Improve Makefile option

### DIFF
--- a/verify/terraform/skus/windows-11-23H2/Makefile
+++ b/verify/terraform/skus/windows-11-23H2/Makefile
@@ -2,12 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-.PHONY: apply ansible destroy
+.PHONY: all terraform.tfvars apply apply-playbook destroy clean
 
 SHELL=/bin/bash
 
-all: clean
-	apply
+all: clean apply
 
 terraform.tfvars:
 	cat ../../modules/terraform.tfvars.template | \

--- a/verify/terraform/skus/windows-11-23H2/Makefile
+++ b/verify/terraform/skus/windows-11-23H2/Makefile
@@ -6,7 +6,9 @@
 
 SHELL=/bin/bash
 
-all: apply
+all:
+	clean
+	apply
 
 terraform.tfvars:
 	cat ../../modules/terraform.tfvars.template | \
@@ -23,4 +25,6 @@ destroy:
 	terraform destroy -auto-approve
 
 clean:
-	rm -rf terraform.tfvars .terraform terraform.tfstate terraform.tfstate.backup
+	rm -rf .terraform .terraform.lock.hcl password.txt terraform.tfstate terraform.tfstate.backup terraform.tfvars \
+		rdp/add_password.bat rdp/*.rdp
+

--- a/verify/terraform/skus/windows-11-23H2/Makefile
+++ b/verify/terraform/skus/windows-11-23H2/Makefile
@@ -6,13 +6,13 @@
 
 SHELL=/bin/bash
 
-all:
-	clean
+all: clean
 	apply
 
 terraform.tfvars:
 	cat ../../modules/terraform.tfvars.template | \
-              sed -e "/^windows-password = \"%PASSWORD%\"/c windows-password = \"$$(pwgen -s --remove-chars=\'\"$$%{} -y 20 1)\"" > terraform.tfvars
+        sed -e "/^windows-password = \"%PASSWORD%\"/c windows-password = \"$$(pwgen -s --remove-chars=\'\"$$%{} -y 20 1)\"" > terraform.tfvars
+
 apply: terraform.tfvars
 	terraform init
 	terraform plan
@@ -27,4 +27,3 @@ destroy:
 clean:
 	rm -rf .terraform .terraform.lock.hcl password.txt terraform.tfstate terraform.tfstate.backup terraform.tfvars \
 		rdp/add_password.bat rdp/*.rdp
-


### PR DESCRIPTION
Related to the comment in PR #35 ;
Added the following items to the clean target.

> How about removing the following generated files in Makefile clean target?
> 
>     * rdp/add_password.bat
> 
>     * rdp/*.rdp
> 
>     * password.txt
> 
>     * .terraform.lock.hcl

And modified a few more description so that "make destroy" then "make all" work repeatedly well.

Although `password.txt` is not always there as it will be removed during "make destroy", I'm in favor of including it in the clean target.