### PR TITLE
Remove terraform.tfvars from .PHONY

### DIFF
--- a/verify/terraform/skus/windows-11-23H2/Makefile
+++ b/verify/terraform/skus/windows-11-23H2/Makefile
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-.PHONY: all terraform.tfvars apply apply-playbook destroy clean
+.PHONY: all apply apply-playbook destroy clean
 
 SHELL=/bin/bash
 


### PR DESCRIPTION
Remove the target of terraform.tfvars from .PHONY as I had mistakenly changed by PR #35 the implicit specification of skipping makefile if `terraform.tfvars` is already there.

I am issuing this in prior to PR #38 since this fix has to do with it.
