### PR TITLE
Generate passwords without backslashes

### DIFF
--- a/verify/terraform/skus/use-in-common.mk
+++ b/verify/terraform/skus/use-in-common.mk
@@ -10,7 +10,7 @@ all: clean apply
 
 terraform.tfvars:
 	cat ../../modules/terraform.tfvars.template | \
-        sed -e "/^windows-password = \"%PASSWORD%\"/c windows-password = \"$$(pwgen -s --remove-chars=\'\"$$%{} -y 20 1)\"" > terraform.tfvars
+        sed -e "/^windows-password = \"%PASSWORD%\"/c windows-password = \"$$(pwgen -s --remove-chars=\'\"$$%{}\\ -y 20 1)\"" > terraform.tfvars
 
 apply: terraform.tfvars
 	terraform init


### PR DESCRIPTION
This fixes the problem reported at https://github.com/clear-code/firefox-support-common/pull/51#issuecomment-2463633584