### PR TITLE
Never use backquote for passwords

### DIFF
--- a/verify/terraform/skus/use-in-common.mk
+++ b/verify/terraform/skus/use-in-common.mk
@@ -10,7 +10,7 @@ all: clean apply
 
 terraform.tfvars:
 	cat ../../modules/terraform.tfvars.template | \
-        sed -e "/^windows-password = \"%PASSWORD%\"/c windows-password = \"$$(pwgen -s --remove-chars=\'\"$$%{}\\ -y 20 1)\"" > terraform.tfvars
+        sed -e "/^windows-password = \"%PASSWORD%\"/c windows-password = \"$$(pwgen -s --remove-chars=\'\"\`$$%{}\\ -y 20 1)\"" > terraform.tfvars
 
 apply: terraform.tfvars
 	terraform init


### PR DESCRIPTION
Backquote in passwords may produce an error on VM initialization, like as:

```
│ Error: compute.VirtualMachinesClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="InvalidParameter" Message="The value of parameter windowsConfiguration.additionalUnattendContent.content is invalid." Target="windowsConfiguration.additionalUnattendContent.content"
│
│   with module.firefox_verify_env.azurerm_virtual_machine.firefoxverify_vm,
│   on ../../modules/main.tf line 54, in resource "azurerm_virtual_machine" "firefoxverify_vm":
│   54: resource "azurerm_virtual_machine" "firefoxverify_vm" {
```

This PR rejects backquote character from generated passwords for more safety.