### PR TITLE
Never use dangerous chars in passwords to avoid XML validation error

### DIFF
--- a/verify/terraform/skus/use-in-common.mk
+++ b/verify/terraform/skus/use-in-common.mk
@@ -10,7 +10,7 @@ all: clean apply
 
 terraform.tfvars:
 	cat ../../modules/terraform.tfvars.template | \
-        sed -e "/^windows-password = \"%PASSWORD%\"/c windows-password = \"$$(pwgen -s --remove-chars=\'\"\`$$%{}\\ -y 20 1)\"" > terraform.tfvars
+        sed -e "/^windows-password = \"%PASSWORD%\"/c windows-password = \"$$(pwgen -s --remove-chars=\'\"\`$$%{}\\\<\>\& -y 20 1)\"" > terraform.tfvars
 
 apply: terraform.tfvars
 	terraform init


### PR DESCRIPTION
This is followup of #53.

Generated password is embedded into the template directly:

```
      content      = "<AutoLogon><Password><Value>${var.windows-password}</Value></Password><Enabled>true</Enabled><LogonCount>1</LogonCount><Username>${var.windows-username}</Username></AutoLogon>"
```

thus some characters `<`, `>` and `&` may cause XML validation error. This PR rejects those chars from generated passwords.