### PR TITLE
Setup windows server as ad dc

### DIFF
--- a/verify/environment/modules/main.tf
+++ b/verify/environment/modules/main.tf
@@ -273,6 +273,13 @@ resource "local_file" "playbook" {
         Remove-Item $LpTemp -Force
     - win_reboot:
       when: not "${var.windows-language-pack-url}" == ""
+    - name: Wait for the system to be ready after reboot for language pack
+      wait_for:
+        host: "{{ansible_host}}"
+        port: 5986
+        delay: 10
+        timeout: 300
+      when: not "${var.windows-language-pack-url}" == ""
     - win_timezone:
         timezone: Tokyo Standard Time
     - name: Set location
@@ -286,6 +293,12 @@ resource "local_file" "playbook" {
     - name: Set keyboard layout
       win_shell: Set-ItemProperty 'registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\i8042prt\Parameters' -Name 'LayerDriver JPN' -Value 'kbd106.dll'
     - win_reboot:
+    - name: Wait for the system to be ready after reboot for locale settings
+      wait_for:
+        host: "{{ansible_host}}"
+        port: 5986
+        delay: 10
+        timeout: 300
     - name: Set region globally
       win_region:
         copy_settings: yes
@@ -293,6 +306,12 @@ resource "local_file" "playbook" {
         format: ja-JP
         unicode_language: ja-JP
     - win_reboot:
+    - name: Wait for the system to be ready after reboot for region settings
+      wait_for:
+        host: "{{ansible_host}}"
+        port: 5986
+        delay: 10
+        timeout: 300
     - name: Create administrator user
       win_user:
         name: "管理者"

--- a/verify/environment/modules/main.tf
+++ b/verify/environment/modules/main.tf
@@ -274,9 +274,7 @@ resource "local_file" "playbook" {
     - win_reboot:
       when: not "${var.windows-language-pack-url}" == ""
     - name: Wait for the system to be ready after reboot for language pack
-      wait_for:
-        host: "{{ansible_host}}"
-        port: 5986
+      ansible.builtin.wait_for_connection:
         delay: 10
         timeout: 300
       when: not "${var.windows-language-pack-url}" == ""
@@ -294,9 +292,7 @@ resource "local_file" "playbook" {
       win_shell: Set-ItemProperty 'registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\i8042prt\Parameters' -Name 'LayerDriver JPN' -Value 'kbd106.dll'
     - win_reboot:
     - name: Wait for the system to be ready after reboot for locale settings
-      wait_for:
-        host: "{{ansible_host}}"
-        port: 5986
+      ansible.builtin.wait_for_connection:
         delay: 10
         timeout: 300
     - name: Set region globally
@@ -307,9 +303,7 @@ resource "local_file" "playbook" {
         unicode_language: ja-JP
     - win_reboot:
     - name: Wait for the system to be ready after reboot for region settings
-      wait_for:
-        host: "{{ansible_host}}"
-        port: 5986
+      ansible.builtin.wait_for_connection:
         delay: 10
         timeout: 300
     - name: Create administrator user
@@ -386,9 +380,7 @@ resource "local_file" "playbook" {
       win_reboot:
       when: promote_dc.changed
     - name: Wait for the system to be ready after reboot for AD DC promotion
-      wait_for:
-        host: "{{ansible_host}}"
-        port: 5986
+      ansible.builtin.wait_for_connection:
         delay: 10
         timeout: 300
       when: promote_dc.changed


### PR DESCRIPTION
This adds some tasks to setup a Windows Server VM as an Active Directory Domain Controller. Those added tasks are skipped for non-server Windows clients.