### PR TITLE
Designate public ip as standard SKU

### DIFF
--- a/verify/terraform/modules/main.tf
+++ b/verify/terraform/modules/main.tf
@@ -191,6 +191,7 @@ resource "azurerm_public_ip" "firefoxverify" {
   name                    = "firefoxverify-${var.namespace}-collector-pip"
   location                = azurerm_resource_group.firefoxverify.location
   resource_group_name     = azurerm_resource_group.firefoxverify.name
+  sku                     = "Standard"
   allocation_method       = "Dynamic"
   idle_timeout_in_minutes = 30
 

--- a/verify/terraform/modules/main.tf
+++ b/verify/terraform/modules/main.tf
@@ -192,7 +192,7 @@ resource "azurerm_public_ip" "firefoxverify" {
   location                = azurerm_resource_group.firefoxverify.location
   resource_group_name     = azurerm_resource_group.firefoxverify.name
   sku                     = "Standard"
-  allocation_method       = "Dynamic"
+  allocation_method       = "Static"
   idle_timeout_in_minutes = 30
 
   tags = {


### PR DESCRIPTION
As Microsoft announces, Basic SKU public IP addresses will be retired in Azure on Sep. 30, 2025.
cf. https://azure.microsoft.com/en-us/updates?id=upgrade-to-standard-sku-public-ip-addresses-in-azure-by-30-september-2025-basic-sku-will-be-retired

Fix to designate public ip as Standard SKU.