### PR TITLE
Update SKU for old windows

### DIFF
--- a/verify/terraform/modules/main.tf
+++ b/verify/terraform/modules/main.tf
@@ -340,6 +340,13 @@ resource "local_file" "playbook" {
       become: yes
       become_user: "ユーザー"
       win_command: reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v HideFileExt /t REG_DWORD /d 0 /f
+    - name: Download Microsoft .NET Framework 4.8 Offline Installer
+      # See also: https://support.microsoft.com/en-us/topic/microsoft-net-framework-4-8-offline-installer-for-windows-9d23f658-3b97-68ab-d013-aa3c3e7495e0
+      win_get_url:
+        url: "https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/ndp48-x86-x64-allos-enu.exe"
+        dest: 'c:\Users\Public\dotnet48_installer.exe'
+    - name: Install Microsoft .NET Framework 4.8 for chocolatey
+      win_command: c:\Users\Public\dotnet48_installer.exe /Q
     - name: Setup chocolatey
       win_chocolatey:
         name: chocolatey

--- a/verify/terraform/modules/variables.tf
+++ b/verify/terraform/modules/variables.tf
@@ -45,7 +45,7 @@ variable "sku" {
     # var.sku は win??-??h?-ent の形式か、 ????-datacenter を含む
     # 古いものには -pro や -enterprise もある
     validation {
-        condition     = endswith(var.sku, "-ent") || strcontains(var.sku, "-datacenter") || endswith(var.sku, "-pro") || endswith(var.sku, "-enterprise") 
+        condition     = endswith(var.sku, "-ent") || strcontains(var.sku, "-datacenter") || strcontains(var.sku, "-Datacenter") || endswith(var.sku, "-pro") || endswith(var.sku, "-pron-g2") || endswith(var.sku, "-pron-gensecond") || endswith(var.sku, "-enterprise") 
         error_message = "The value of var.sku must contain '-ent', or '-datacenter', but it is '${var.sku}'."
     }
 }

--- a/verify/terraform/skus/windows-10-1903/variables.tf
+++ b/verify/terraform/skus/windows-10-1903/variables.tf
@@ -21,5 +21,5 @@ variable "publisher" {
 variable "sku" {
     description = "value for storage_image_reference"
     type        = string
-    default     = "19h1-pro"
+    default     = "19h1-pron-gensecond"
 }

--- a/verify/terraform/skus/windows-10-1909/variables.tf
+++ b/verify/terraform/skus/windows-10-1909/variables.tf
@@ -21,5 +21,5 @@ variable "publisher" {
 variable "sku" {
     description = "value for storage_image_reference"
     type        = string
-    default     = "19h2-pro"
+    default     = "19h2-pron-g2"
 }


### PR DESCRIPTION
Some SKUs of old version Windows look to be disappeared. We need to update VM parameters to follow up to the change.

And this PR also adds extra tasks to install .NET Framework 4.8 which is required by Chocolatey but not installed in old versions of Windows.