### PR TITLE
Use microsoft.ad.membership instead as ansible.windows.win_domain_membership has been deprecated.

### DIFF
--- a/verify/terraform/modules/main.tf
+++ b/verify/terraform/modules/main.tf
@@ -246,7 +246,7 @@ resource "local_file" "playbook" {
         data: 00000000
         datatype: dword
     - name: Set non-ASCII workgroup name
-      win_domain_membership:
+      microsoft.ad.membership:
         domain_admin_user: "${var.windows-username}"
         domain_admin_password: "${var.windows-password}"
         state: workgroup


### PR DESCRIPTION
This PR resolves Issue #58.
A test run creating a Windows 11 23H2 environment on Azure worked fine.

For details of the ansible module to migrate, see https://docs.ansible.com/ansible/latest/collections/microsoft/ad/docsite/guide_migration.html#module-win-domain-membership