### PR TITLE
Add win11-24h2-ent sku

### DIFF
--- a/verify/environment/skus/windows-11-24H2/Makefile
+++ b/verify/environment/skus/windows-11-24H2/Makefile
@@ -1,0 +1,6 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Include to use Makefile under "skus" directory in common
+include ../use-in-common.mk

--- a/verify/environment/skus/windows-11-24H2/main.tf
+++ b/verify/environment/skus/windows-11-24H2/main.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_version = ">= 1.7.5"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~>2.10"
+    }
+
+    local = {
+      source  = "hashicorp/local"
+      version = "~>1.4"
+    }
+  }
+}
+
+module "firefox_verify_env" {
+  source            = "../../modules"
+
+  namespace         = var.namespace
+  windows-password  = var.windows-password
+
+  offer             = var.offer
+  publisher         = var.publisher
+  sku               = var.sku
+}

--- a/verify/environment/skus/windows-11-24H2/variables.tf
+++ b/verify/environment/skus/windows-11-24H2/variables.tf
@@ -1,7 +1,7 @@
 variable "namespace" {
     description = "Prefix example- and the sku type to use as a part of environment name"
     type        = string
-    default     = "example-win11-ent-23H2"
+    default     = "example-win11-ent-24H2"
 }
 variable "windows-password" {
     description = "Windows login password, whose value is in terraform.tfvars"
@@ -21,5 +21,5 @@ variable "publisher" {
 variable "sku" {
     description = "value for storage_image_reference"
     type        = string
-    default     = "win11-23h2-ent"
+    default     = "win11-24h2-ent"
 }

--- a/verify/environment/skus/windows-11-24H2/variables.tf
+++ b/verify/environment/skus/windows-11-24H2/variables.tf
@@ -1,0 +1,25 @@
+variable "namespace" {
+    description = "Prefix example- and the sku type to use as a part of environment name"
+    type        = string
+    default     = "example-win11-ent-23H2"
+}
+variable "windows-password" {
+    description = "Windows login password, whose value is in terraform.tfvars"
+    type        = string
+}
+
+variable "offer" {
+    description = "value for storage_image_reference"
+    type        = string
+    default     = "Windows-11"
+}
+variable "publisher" {
+    description = "value for storage_image_reference"
+    type        = string
+    default     = "MicrosoftWindowsDesktop"
+}
+variable "sku" {
+    description = "value for storage_image_reference"
+    type        = string
+    default     = "win11-23h2-ent"
+}


### PR DESCRIPTION
Add a new sku set for creating a Windows 11 24H2 environment.