### PR TITLE
Resolve Template variable warning

### DIFF
--- a/assets/esr140.var
+++ b/assets/esr140.var
@@ -28,6 +28,7 @@ imported_certs:                 Test Cert
 install_path_32bit:
 Application_1_3_desktop_shortcut_path_32bit:
 Application_2_3_start_menu_shortcut_path_32bit:
+Application_6_2_special_profile_actual_path:
 
 COVER:
 

--- a/assets/esr140.var
+++ b/assets/esr140.var
@@ -26,8 +26,6 @@ imported_certs:                 Test Cert
 
 # 未使用
 install_path_32bit:
-desktop_shortcut_path_32bit:
-start_menu_shortcut_path_32bit:
 
 COVER:
 

--- a/assets/esr140.var
+++ b/assets/esr140.var
@@ -26,7 +26,7 @@ imported_certs:                 Test Cert
 
 # 未使用
 install_path_32bit:
-desktop_shortcut_path_32bit:
+Application_1_3_desktop_shortcut_path_32bit:
 start_menu_shortcut_path_32bit:
 
 COVER:

--- a/assets/esr140.var
+++ b/assets/esr140.var
@@ -27,7 +27,7 @@ imported_certs:                 Test Cert
 # 未使用
 install_path_32bit:
 Application_1_3_desktop_shortcut_path_32bit:
-start_menu_shortcut_path_32bit:
+Application_2_3_start_menu_shortcut_path_32bit:
 
 COVER:
 

--- a/assets/esr140.var
+++ b/assets/esr140.var
@@ -26,6 +26,8 @@ imported_certs:                 Test Cert
 
 # 未使用
 install_path_32bit:
+desktop_shortcut_path_32bit:
+start_menu_shortcut_path_32bit:
 
 COVER:
 

--- a/verify/PRETEXT
+++ b/verify/PRETEXT
@@ -20,9 +20,9 @@ PRETEXT-1: 前提条件
     - Firefoxは次のパスにインストールする。
         - `{{install_path}}` {%if install_path_32bit %} （32bit環境では `{{install_path_32bit}}`）{% endif %}{%if desktop_shortcut %}
     - デスクトップのショートカットは次のパスに作成する。
-        - `{{desktop_shortcut_path}}` {% endif %}{%if start_menu_shortcut %}
+        - `{{desktop_shortcut_path}}` {%if desktop_shortcut_path_32bit %} （32bit環境では `{{desktop_shortcut_path_32bit}}`）{% endif %}{% endif %}{%if start_menu_shortcut %}
     - スタートメニューのショートカットは次のパスに作成する。
-        - `{{start_menu_shortcut_path}}` {% endif %}
+        - `{{start_menu_shortcut_path}}` {%if start_menu_shortcut_path_32bit %} （32bit環境では `{{start_menu_shortcut_path_32bit}}`）{% endif %}{% endif %}
     {% endif %}
 
     :3: 検証の準備

--- a/verify/PRETEXT
+++ b/verify/PRETEXT
@@ -22,7 +22,7 @@ PRETEXT-1: 前提条件
     - デスクトップのショートカットは次のパスに作成する。
         - `{{desktop_shortcut_path}}` {%if Application_1_3_desktop_shortcut_path_32bit %} （32bit環境では `{{Application_1_3_desktop_shortcut_path_32bit}}`）{% endif %}{% endif %}{%if start_menu_shortcut %}
     - スタートメニューのショートカットは次のパスに作成する。
-        - `{{start_menu_shortcut_path}}` {%if start_menu_shortcut_path_32bit %} （32bit環境では `{{start_menu_shortcut_path_32bit}}`）{% endif %}{% endif %}
+        - `{{start_menu_shortcut_path}}` {%if Application_2_3_start_menu_shortcut_path_32bit %} （32bit環境では `{{Application_2_3_start_menu_shortcut_path_32bit}}`）{% endif %}{% endif %}
     {% endif %}
 
     :3: 検証の準備

--- a/verify/PRETEXT
+++ b/verify/PRETEXT
@@ -20,9 +20,9 @@ PRETEXT-1: 前提条件
     - Firefoxは次のパスにインストールする。
         - `{{install_path}}` {%if install_path_32bit %} （32bit環境では `{{install_path_32bit}}`）{% endif %}{%if desktop_shortcut %}
     - デスクトップのショートカットは次のパスに作成する。
-        - `{{desktop_shortcut_path}}` {%if desktop_shortcut_path_32bit %} （32bit環境では `{{desktop_shortcut_path_32bit}}`）{% endif %}{% endif %}{%if start_menu_shortcut %}
+        - `{{desktop_shortcut_path}}` {% endif %}{%if start_menu_shortcut %}
     - スタートメニューのショートカットは次のパスに作成する。
-        - `{{start_menu_shortcut_path}}` {%if start_menu_shortcut_path_32bit %} （32bit環境では `{{start_menu_shortcut_path_32bit}}`）{% endif %}{% endif %}
+        - `{{start_menu_shortcut_path}}` {% endif %}
     {% endif %}
 
     :3: 検証の準備

--- a/verify/PRETEXT
+++ b/verify/PRETEXT
@@ -20,7 +20,7 @@ PRETEXT-1: 前提条件
     - Firefoxは次のパスにインストールする。
         - `{{install_path}}` {%if install_path_32bit %} （32bit環境では `{{install_path_32bit}}`）{% endif %}{%if desktop_shortcut %}
     - デスクトップのショートカットは次のパスに作成する。
-        - `{{desktop_shortcut_path}}` {%if desktop_shortcut_path_32bit %} （32bit環境では `{{desktop_shortcut_path_32bit}}`）{% endif %}{% endif %}{%if start_menu_shortcut %}
+        - `{{desktop_shortcut_path}}` {%if Application_1_3_desktop_shortcut_path_32bit %} （32bit環境では `{{Application_1_3_desktop_shortcut_path_32bit}}`）{% endif %}{% endif %}{%if start_menu_shortcut %}
     - スタートメニューのショートカットは次のパスに作成する。
         - `{{start_menu_shortcut_path}}` {%if start_menu_shortcut_path_32bit %} （32bit環境では `{{start_menu_shortcut_path_32bit}}`）{% endif %}{% endif %}
     {% endif %}

--- a/verify/Privacy
+++ b/verify/Privacy
@@ -953,8 +953,8 @@ Privacy-34: フォームへのユーザー入力値のセッション情報へ�
     :1: 許可する（既定）
 
     - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル \
-      `{{special_profile_path}}` {%if special_profile_actual_path %} \
-      （{{special_profile_actual_path}}）{% endif %} \
+      `{{special_profile_path}}` {%if Application_6_2_special_profile_actual_path %} \
+      （{{Application_6_2_special_profile_actual_path}}）{% endif %} \
       を削除する。
     - Firefoxを起動する。
     - テストケースの `password.html` を開く。
@@ -969,8 +969,8 @@ Privacy-34: フォームへのユーザー入力値のセッション情報へ�
     :2: 一切禁止する
 
     - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル \
-      `{{special_profile_path}}` {%if special_profile_actual_path %} \
-      （{{special_profile_actual_path}}）{% endif %} \
+      `{{special_profile_path}}` {%if Application_6_2_special_profile_actual_path %} \
+      （{{Application_6_2_special_profile_actual_path}}）{% endif %} \
       を削除する。
     - Firefoxを起動する。
     - テストケースの `password.html` を開く。
@@ -1032,7 +1032,7 @@ Privacy-36: TLS/SSLで保護された通信のコンテンツのディスク上�
     - 先ほど開いたディスクキャッシュの保存先フォルダを開き、その1つ上位のフォルダに移動して、中にある `thumbnails` フォルダを消去する。
       {% endif %}
       {% if Application_6_2 %}
-    - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル `{{special_profile_path}}` {%if special_profile_actual_path %} （{{special_profile_actual_path}}）{% endif %} 内のファイルを削除する。
+    - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル `{{special_profile_path}}` {%if Application_6_2_special_profile_actual_path %} （{{Application_6_2_special_profile_actual_path}}）{% endif %} 内のファイルを削除する。
       {% endif %}
     - Firefoxを起動する。
       {%if Tab_17_2 %}
@@ -1069,7 +1069,7 @@ Privacy-36: TLS/SSLで保護された通信のコンテンツのディスク上�
     - 先ほど開いたディスクキャッシュの保存先フォルダを開き、その1つ上位のフォルダに移動して、中にある `thumbnails` フォルダを消去する。
       {% endif %}
       {% if Application_6_2 %}
-    - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル `{{special_profile_path}}` {%if special_profile_actual_path %} （{{special_profile_actual_path}}）{% endif %} 内のファイルを削除する。
+    - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル `{{special_profile_path}}` {%if Application_6_2_special_profile_actual_path %} （{{Application_6_2_special_profile_actual_path}}）{% endif %} 内のファイルを削除する。
       {% endif %}
     - Firefoxを起動する。
       {%if Tab_17_2 %}
@@ -1545,8 +1545,8 @@ Privacy-52: プライバシーに関する通知タブの表示の可否
     :1: 表示する（既定）: not Privacy_18_3
 
     - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル \
-      `{{special_profile_path}}` {%if special_profile_actual_path %} \
-      （{{special_profile_actual_path}}）{% endif %} \
+      `{{special_profile_path}}` {%if Application_6_2_special_profile_actual_path %} \
+      （{{Application_6_2_special_profile_actual_path}}）{% endif %} \
       を空にする。
     - Firefoxを起動する。
     - **確認**
@@ -1568,8 +1568,8 @@ Privacy-52: プライバシーに関する通知タブの表示の可否
     :2: 表示しない: not Privacy_18_3
 
     - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル \
-      `{{special_profile_path}}` {%if special_profile_actual_path %} \
-      （{{special_profile_actual_path}}）{% endif %} \
+      `{{special_profile_path}}` {%if Application_6_2_special_profile_actual_path %} \
+      （{{Application_6_2_special_profile_actual_path}}）{% endif %} \
       を空にする。
     - Firefoxを起動する。
     - **確認**
@@ -1866,8 +1866,8 @@ Privacy-64: SameSite指定が無いCookieの取り扱い
     :1: クロスサイトでの送信を常に許可 (既定）
 
     - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル \
-      `{{special_profile_path}}` {%if special_profile_actual_path %} \
-      （{{special_profile_actual_path}}）{% endif %} \
+      `{{special_profile_path}}` {%if Application_6_2_special_profile_actual_path %} \
+      （{{Application_6_2_special_profile_actual_path}}）{% endif %} \
       を削除する。
     - Firefoxを起動する。
     - テストケースリストのリンクから \
@@ -1882,8 +1882,8 @@ Privacy-64: SameSite指定が無いCookieの取り扱い
     :2: クロスサイトでの送信をサブリソースに対しては禁止する
 
     - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル \
-      `{{special_profile_path}}` {%if special_profile_actual_path %} \
-      （{{special_profile_actual_path}}）{% endif %} \
+      `{{special_profile_path}}` {%if Application_6_2_special_profile_actual_path %} \
+      （{{Application_6_2_special_profile_actual_path}}）{% endif %} \
       を削除する。
     - Firefoxを起動する。
     - テストケースリストのリンクから \
@@ -1898,8 +1898,8 @@ Privacy-64: SameSite指定が無いCookieの取り扱い
     :3: クロスサイトでの送信をサブリソースに対しては禁止し、特定サイトでのみクロスサイトでの送信を常に許可
 
     - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル \
-      `{{special_profile_path}}` {%if special_profile_actual_path %} \
-      （{{special_profile_actual_path}}）{% endif %} \
+      `{{special_profile_path}}` {%if Application_6_2_special_profile_actual_path %} \
+      （{{Application_6_2_special_profile_actual_path}}）{% endif %} \
       を削除する。
     - Firefoxを起動する。
     - テストケースリストのリンクから \
@@ -1912,8 +1912,8 @@ Privacy-64: SameSite指定が無いCookieの取り扱い
         - 遷移後のページの `noCokkie` に `◯` が表示されていない。
     - ポリシー設定を変更し `demo.isystk.com` をクロスサイトでのCookie送信許可サイトに加える。
     - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル \
-      `{{special_profile_path}}` {%if special_profile_actual_path %} \
-      （{{special_profile_actual_path}}）{% endif %} \
+      `{{special_profile_path}}` {%if Application_6_2_special_profile_actual_path %} \
+      （{{Application_6_2_special_profile_actual_path}}）{% endif %} \
       を削除する。
     - Firefoxを起動する。
     - テストケースリストのリンクから \

--- a/verify/Privacy
+++ b/verify/Privacy
@@ -953,7 +953,8 @@ Privacy-34: フォームへのユーザー入力値のセッション情報へ�
     :1: 許可する（既定）
 
     - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル \
-      `{{special_profile_path}}` \
+      `{{special_profile_path}}` {%if special_profile_actual_path %} \
+      （{{special_profile_actual_path}}）{% endif %} \
       を削除する。
     - Firefoxを起動する。
     - テストケースの `password.html` を開く。
@@ -968,7 +969,8 @@ Privacy-34: フォームへのユーザー入力値のセッション情報へ�
     :2: 一切禁止する
 
     - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル \
-      `{{special_profile_path}}` \
+      `{{special_profile_path}}` {%if special_profile_actual_path %} \
+      （{{special_profile_actual_path}}）{% endif %} \
       を削除する。
     - Firefoxを起動する。
     - テストケースの `password.html` を開く。
@@ -1030,7 +1032,7 @@ Privacy-36: TLS/SSLで保護された通信のコンテンツのディスク上�
     - 先ほど開いたディスクキャッシュの保存先フォルダを開き、その1つ上位のフォルダに移動して、中にある `thumbnails` フォルダを消去する。
       {% endif %}
       {% if Application_6_2 %}
-    - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル `{{special_profile_path}}` 内のファイルを削除する。
+    - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル `{{special_profile_path}}` {%if special_profile_actual_path %} （{{special_profile_actual_path}}）{% endif %} 内のファイルを削除する。
       {% endif %}
     - Firefoxを起動する。
       {%if Tab_17_2 %}
@@ -1067,7 +1069,7 @@ Privacy-36: TLS/SSLで保護された通信のコンテンツのディスク上�
     - 先ほど開いたディスクキャッシュの保存先フォルダを開き、その1つ上位のフォルダに移動して、中にある `thumbnails` フォルダを消去する。
       {% endif %}
       {% if Application_6_2 %}
-    - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル `{{special_profile_path}}` 内のファイルを削除する。
+    - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル `{{special_profile_path}}` {%if special_profile_actual_path %} （{{special_profile_actual_path}}）{% endif %} 内のファイルを削除する。
       {% endif %}
     - Firefoxを起動する。
       {%if Tab_17_2 %}
@@ -1543,7 +1545,8 @@ Privacy-52: プライバシーに関する通知タブの表示の可否
     :1: 表示する（既定）: not Privacy_18_3
 
     - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル \
-      `{{special_profile_path}}` \
+      `{{special_profile_path}}` {%if special_profile_actual_path %} \
+      （{{special_profile_actual_path}}）{% endif %} \
       を空にする。
     - Firefoxを起動する。
     - **確認**
@@ -1565,7 +1568,8 @@ Privacy-52: プライバシーに関する通知タブの表示の可否
     :2: 表示しない: not Privacy_18_3
 
     - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル \
-      `{{special_profile_path}}` \
+      `{{special_profile_path}}` {%if special_profile_actual_path %} \
+      （{{special_profile_actual_path}}）{% endif %} \
       を空にする。
     - Firefoxを起動する。
     - **確認**
@@ -1862,7 +1866,8 @@ Privacy-64: SameSite指定が無いCookieの取り扱い
     :1: クロスサイトでの送信を常に許可 (既定）
 
     - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル \
-      `{{special_profile_path}}` \
+      `{{special_profile_path}}` {%if special_profile_actual_path %} \
+      （{{special_profile_actual_path}}）{% endif %} \
       を削除する。
     - Firefoxを起動する。
     - テストケースリストのリンクから \
@@ -1877,7 +1882,8 @@ Privacy-64: SameSite指定が無いCookieの取り扱い
     :2: クロスサイトでの送信をサブリソースに対しては禁止する
 
     - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル \
-      `{{special_profile_path}}` \
+      `{{special_profile_path}}` {%if special_profile_actual_path %} \
+      （{{special_profile_actual_path}}）{% endif %} \
       を削除する。
     - Firefoxを起動する。
     - テストケースリストのリンクから \
@@ -1892,7 +1898,8 @@ Privacy-64: SameSite指定が無いCookieの取り扱い
     :3: クロスサイトでの送信をサブリソースに対しては禁止し、特定サイトでのみクロスサイトでの送信を常に許可
 
     - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル \
-      `{{special_profile_path}}` \
+      `{{special_profile_path}}` {%if special_profile_actual_path %} \
+      （{{special_profile_actual_path}}）{% endif %} \
       を削除する。
     - Firefoxを起動する。
     - テストケースリストのリンクから \
@@ -1905,7 +1912,8 @@ Privacy-64: SameSite指定が無いCookieの取り扱い
         - 遷移後のページの `noCokkie` に `◯` が表示されていない。
     - ポリシー設定を変更し `demo.isystk.com` をクロスサイトでのCookie送信許可サイトに加える。
     - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル \
-      `{{special_profile_path}}` \
+      `{{special_profile_path}}` {%if special_profile_actual_path %} \
+      （{{special_profile_actual_path}}）{% endif %} \
       を削除する。
     - Firefoxを起動する。
     - テストケースリストのリンクから \

--- a/verify/Privacy
+++ b/verify/Privacy
@@ -953,8 +953,7 @@ Privacy-34: フォームへのユーザー入力値のセッション情報へ�
     :1: 許可する（既定）
 
     - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル \
-      `{{special_profile_path}}` {%if special_profile_actual_path %} \
-      （{{special_profile_actual_path}}）{% endif %} \
+      `{{special_profile_path}}` \
       を削除する。
     - Firefoxを起動する。
     - テストケースの `password.html` を開く。
@@ -969,8 +968,7 @@ Privacy-34: フォームへのユーザー入力値のセッション情報へ�
     :2: 一切禁止する
 
     - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル \
-      `{{special_profile_path}}` {%if special_profile_actual_path %} \
-      （{{special_profile_actual_path}}）{% endif %} \
+      `{{special_profile_path}}` \
       を削除する。
     - Firefoxを起動する。
     - テストケースの `password.html` を開く。
@@ -1032,7 +1030,7 @@ Privacy-36: TLS/SSLで保護された通信のコンテンツのディスク上�
     - 先ほど開いたディスクキャッシュの保存先フォルダを開き、その1つ上位のフォルダに移動して、中にある `thumbnails` フォルダを消去する。
       {% endif %}
       {% if Application_6_2 %}
-    - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル `{{special_profile_path}}` {%if special_profile_actual_path %} （{{special_profile_actual_path}}）{% endif %} 内のファイルを削除する。
+    - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル `{{special_profile_path}}` 内のファイルを削除する。
       {% endif %}
     - Firefoxを起動する。
       {%if Tab_17_2 %}
@@ -1069,7 +1067,7 @@ Privacy-36: TLS/SSLで保護された通信のコンテンツのディスク上�
     - 先ほど開いたディスクキャッシュの保存先フォルダを開き、その1つ上位のフォルダに移動して、中にある `thumbnails` フォルダを消去する。
       {% endif %}
       {% if Application_6_2 %}
-    - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル `{{special_profile_path}}` {%if special_profile_actual_path %} （{{special_profile_actual_path}}）{% endif %} 内のファイルを削除する。
+    - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル `{{special_profile_path}}` 内のファイルを削除する。
       {% endif %}
     - Firefoxを起動する。
       {%if Tab_17_2 %}
@@ -1545,8 +1543,7 @@ Privacy-52: プライバシーに関する通知タブの表示の可否
     :1: 表示する（既定）: not Privacy_18_3
 
     - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル \
-      `{{special_profile_path}}` {%if special_profile_actual_path %} \
-      （{{special_profile_actual_path}}）{% endif %} \
+      `{{special_profile_path}}` \
       を空にする。
     - Firefoxを起動する。
     - **確認**
@@ -1568,8 +1565,7 @@ Privacy-52: プライバシーに関する通知タブの表示の可否
     :2: 表示しない: not Privacy_18_3
 
     - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル \
-      `{{special_profile_path}}` {%if special_profile_actual_path %} \
-      （{{special_profile_actual_path}}）{% endif %} \
+      `{{special_profile_path}}` \
       を空にする。
     - Firefoxを起動する。
     - **確認**
@@ -1866,8 +1862,7 @@ Privacy-64: SameSite指定が無いCookieの取り扱い
     :1: クロスサイトでの送信を常に許可 (既定）
 
     - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル \
-      `{{special_profile_path}}` {%if special_profile_actual_path %} \
-      （{{special_profile_actual_path}}）{% endif %} \
+      `{{special_profile_path}}` \
       を削除する。
     - Firefoxを起動する。
     - テストケースリストのリンクから \
@@ -1882,8 +1877,7 @@ Privacy-64: SameSite指定が無いCookieの取り扱い
     :2: クロスサイトでの送信をサブリソースに対しては禁止する
 
     - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル \
-      `{{special_profile_path}}` {%if special_profile_actual_path %} \
-      （{{special_profile_actual_path}}）{% endif %} \
+      `{{special_profile_path}}` \
       を削除する。
     - Firefoxを起動する。
     - テストケースリストのリンクから \
@@ -1898,8 +1892,7 @@ Privacy-64: SameSite指定が無いCookieの取り扱い
     :3: クロスサイトでの送信をサブリソースに対しては禁止し、特定サイトでのみクロスサイトでの送信を常に許可
 
     - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル \
-      `{{special_profile_path}}` {%if special_profile_actual_path %} \
-      （{{special_profile_actual_path}}）{% endif %} \
+      `{{special_profile_path}}` \
       を削除する。
     - Firefoxを起動する。
     - テストケースリストのリンクから \
@@ -1912,8 +1905,7 @@ Privacy-64: SameSite指定が無いCookieの取り扱い
         - 遷移後のページの `noCokkie` に `◯` が表示されていない。
     - ポリシー設定を変更し `demo.isystk.com` をクロスサイトでのCookie送信許可サイトに加える。
     - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル \
-      `{{special_profile_path}}` {%if special_profile_actual_path %} \
-      （{{special_profile_actual_path}}）{% endif %} \
+      `{{special_profile_path}}` \
       を削除する。
     - Firefoxを起動する。
     - テストケースリストのリンクから \

--- a/verify/Security
+++ b/verify/Security
@@ -412,7 +412,7 @@ Security-15: その他、バックグラウンドで行われる外部への通�
     - ポリシー設定から `BlockAboutAddons` を削除し、アドオンマネージャを一時的に有効化しておく。
       {% endif %}{% endif %}
       {%if UsePACFile %}
-    - プロキシ自動設定スクリプトを参照できない環境で検証する場合、{%if Network_2_3 %}「Network-2-3」{%if Network_2_8 %}または「Network-2-8」{% endif %}での{% else %}{%if Network_2_8 %}「Network-2-8」での{% endif %}{% endif %}PACファイルの参照先URLを `data:application/javascript,` と設定する。
+    - プロキシ自動設定スクリプトを参照できない環境で検証する場合、{%if Network_2_8 %}「Network-2-8」での{% endif %}PACファイルの参照先URLを `data:application/javascript,` と設定する。
       {% endif %}
     - Firefoxを起動する。
     - `about:profiles` または `about:support` から、現在のユーザープロファイルフォルダを開く。


### PR DESCRIPTION
`make verification-manual`実行時にwarningの出る下記各変数は定義されておらず、今後定義する見込みもないことから、使用箇所の記述をすべて削除しました。

* Network_2_3
* desktop_shortcut_path_32bit
* start_menu_shortcut_path_32bit
* special_profile_actual_path

同様のwarningが出る`sanitize_on_shutdown_list`は上記と同じく未定義ですが、Privacy-1-5の確認手順に使用されているため、別途対処を検討します。