### PR TITLE
Remove yet other SyntaxWarning

### DIFF
--- a/adlib.py
+++ b/adlib.py
@@ -47,8 +47,8 @@ from collections import OrderedDict
 # ITEM_MATCHER matches configuration titles.
 # OPTION_MATCHER matches option titles.
 
-ITEM_MATCHER = re.compile('^(\S+): (.+)')
-OPTION_MATCHER = re.compile('^ +:(\d+): (.*about:[^:]+|[^:]+)(: (.+))?')
+ITEM_MATCHER = re.compile(r'^(\S+): (.+)')
+OPTION_MATCHER = re.compile(r'^ +:(\d+): (.*about:[^:]+|[^:]+)(: (.+))?')
 
 def is_comment(line):
     return line.startswith("#")

--- a/xlsxlib.py
+++ b/xlsxlib.py
@@ -322,7 +322,7 @@ class ConfigurationRow:
         return re.sub(' *[^:]+:\n', '', config).strip()
 
     def _omit_redundant_config(self, config):
-        config = re.sub('.*\*\.cfg', '*.cfg', config, flags=(re.DOTALL)).strip()
+        config = re.sub(r'.*\*\.cfg', '*.cfg', config, flags=(re.DOTALL)).strip()
         config = self._omit_gpo_config(config)
         return config
 


### PR DESCRIPTION
このPRはIssue #73 の解消を目指したものです。
PR #82 の補完となります。

firefox-support-commonをSubmoduleに使用している別リポジトリで、`make configurations-sheet`実行時にSyntaxWarningが出ていた箇所に対して、`r`プレフィックスを追加しました。