### PR TITLE
Remove one sed option from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,10 +57,10 @@ verification-manual:
 migration-report: migration-report-docx migration-report-pdf
 
 migration-report-docx:
-	cd migration && cat esr140.md | sed -E -e 's/<!--.*-->//g' -e '/<!--/{:a;N;/-->/!ba;d}' -e 's;(https?://[^ ]+);[\1](\1);g' | pandoc ${PANDOC_OPT_DOCX} -o "../migration-report-esr140-$(DATE).docx"
+	cd migration && cat esr140.md | sed -E -e 's/<!--.*-->//g' -e '/<!--/{:a;N;/-->/!ba;d}' | pandoc ${PANDOC_OPT_DOCX} -o "../migration-report-esr140-$(DATE).docx"
 
 migration-report-pdf:
-	cd migration && cat esr140.md | sed -E -e 's/<!--.*-->//g' -e '/<!--/{:a;N;/-->/!ba;d}' -e 's;(https?://[^ ]+);[\1](\1);g' | pandoc ${PANDOC_OPT_PDF} -o "../migration-report-esr140-$(DATE).pdf"
+	cd migration && cat esr140.md | sed -E -e 's/<!--.*-->//g' -e '/<!--/{:a;N;/-->/!ba;d}' | pandoc ${PANDOC_OPT_PDF} -o "../migration-report-esr140-$(DATE).pdf"
 
 clean:
 	rm -f config-*.xlsx


### PR DESCRIPTION
The Makefile commands to generate a Migration Reports in PDF or DOCX format convert plain HTTP(S) URLs into Markdown hyperlinks with an sed command.

However, this conversion appears unnecessary because:
1. it does not correctly handle URLs already used in Markdown link syntax (`[text](URL)`)
2. and most modern PDF viewers typically recognize plain HTTPS URLs as hyperlinks automatically.

Considering a conflict this PR will open after PR #100 has been merged.
