### PR TITLE
Support line breaks within inline code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ PANDOC_OPT_PDF= -N --toc-depth=2 --table-of-contents \
                 -f markdown \
                 --wrap=preserve \
                 --template=eisvogel.latex \
+                --include-in-header=header.tex \
                 -V documentclass=ltjsarticle \
                 -V classoption=titlepage \
                 --pdf-engine=xelatex

--- a/migration/header.tex
+++ b/migration/header.tex
@@ -1,0 +1,4 @@
+\usepackage{seqsplit}
+
+\let\oldtexttt\texttt
+\renewcommand{\texttt}[1]{\oldtexttt{\seqsplit{#1}}}


### PR DESCRIPTION
In a Migration Report generated in PDF format via the Makefile command, text enclosed in backquotes--which I call it inline code afterwards is apparently rendered as an unbreakable string.
So long inline code often overflows beyond the right margin of the page.

To address this issue, this PR will redefine \texttt{} to allow line breaks within inline code.

Considering a conflict this PR will open after PR #100 has been merged.