### PR TITLE
Modify sec option to convert only described directly as https text

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,10 +58,10 @@ verification-manual:
 migration-report: migration-report-docx migration-report-pdf
 
 migration-report-docx:
-	cd migration && cat esr153.md | sed -E -e 's/<!--.*-->//g' -e '/<!--/{:a;N;/-->/!ba;d}' -e 's;(https?://[^ ]+);[\1](\1);g' | pandoc ${PANDOC_OPT_DOCX} -o "../migration-report-esr153-$(DATE).docx"
+	cd migration && cat esr153.md | sed -E -e 's/<!--.*-->//g' -e '/<!--/{:a;N;/-->/!ba;d}' -e 's;(^|[^()])(https?://[^ )\n]+);\1[\2](\2);g' | pandoc ${PANDOC_OPT_DOCX} -o "../migration-report-esr153-$(DATE).docx"
 
 migration-report-pdf:
-	cd migration && cat esr153.md | sed -E -e 's/<!--.*-->//g' -e '/<!--/{:a;N;/-->/!ba;d}' -e 's;(https?://[^ ]+);[\1](\1);g' | pandoc ${PANDOC_OPT_PDF} -o "../migration-report-esr153-$(DATE).pdf"
+	cd migration && cat esr153.md | sed -E -e 's/<!--.*-->//g' -e '/<!--/{:a;N;/-->/!ba;d}' -e 's;(^|[^()])(https?://[^ )\n]+);\1[\2](\2);g' | pandoc ${PANDOC_OPT_PDF} -o "../migration-report-esr153-$(DATE).pdf"
 
 clean:
 	rm -f config-*.xlsx


### PR DESCRIPTION
The Makefile commands to generate a Migration Report in PDF or DOCX format convert plain HTTP(S) URLs into Markdown hyperlinks with an sed command.
However, this conversion does not correctly handle URLs already used in Markdown link syntax like `[text](URL)`.

To address this issue, this PR limits the conversion to HTTPS URLs written directly in the text.

Considering a conflict this PR will open after PR #103 has been merged.