### PR TITLE
Fix description on AIControls

### DIFF
--- a/esr153/Appearance
+++ b/esr153/Appearance
@@ -538,9 +538,19 @@ Appearance-26: プライベート翻訳機能の使用可否
 
     :1: 許可する（既定）
 
-    Ui-27-2 選択時は共存不可。
+    // Ui-27-2 選択時に設定要。
+    distribution\policies.json:
+    "AIControls": {
+      "Translations": {
+        "Value": "available",
+        "Status": "locked"
+      },
+      ...
+    },
 
-    -
+    GPO:
+    カテゴリ「Firefox」
+    →「Preferences」を有効化し、policies.jsonのPreferencesに設定する内容と同等のJSON文字列を設定
 
     :2: 禁止する
 

--- a/esr153/Ui
+++ b/esr153/Ui
@@ -496,10 +496,23 @@ Ui-24: リンクの長押しによるリンク先のプレビュー表示
 
     :1: 使用する（既定）
 
-    -
+    // Ui-27-2 選択時に設定要。
+    distribution\policies.json:
+    "AIControls": {
+      "LinkPreviewKeyPoints": {
+        "Value": "available",
+        "Locked": true
+      },
+      ...
+    },
+
+    GPO:
+    カテゴリ「Firefox」→「AI Controls」
+    →「Link Preview Key Points」を有効化
 
     :2: 使用しない
 
+    // Ui-27-2 選択時は設定不要。
     distribution\policies.json:
     "AIControls": {
       "LinkPreviewKeyPoints": {


### PR DESCRIPTION
Fix description related to `AIControls` as each configuration:
* is also disabled when the default is set to `blocked`
* can be enabled individually even if the default is `blocked`