### PR TITLE
Configure and verify Privacy-64 only with policies

### DIFF
--- a/esr153/Privacy
+++ b/esr153/Privacy
@@ -1943,9 +1943,6 @@ Privacy-64: SameSite指定が無いCookieの取り扱い
 
     :1: クロスサイトでの送信を常に許可 (既定）
 
-    *.cfg / *.jsc:
-    lockPref("network.cookie.sameSite.laxByDefault", false);
-
     distribution\policies.json:
     "LegacySameSiteCookieBehaviorEnabled": true,
 
@@ -1955,9 +1952,6 @@ Privacy-64: SameSite指定が無いCookieの取り扱い
 
     :2: クロスサイトでの送信をサブリソースに対しては禁止する
 
-    *.cfg / *.jsc:
-    lockPref("network.cookie.sameSite.laxByDefault", true);
-
     distribution\policies.json:
     "LegacySameSiteCookieBehaviorEnabled": false,
 
@@ -1966,10 +1960,6 @@ Privacy-64: SameSite指定が無いCookieの取り扱い
     →「Revert to legacy SameSite behavior」を無効化
 
     :3: クロスサイトでの送信をサブリソースに対しては禁止し、特定サイトでのみクロスサイトでの送信を常に許可
-
-    *.cfg / *.jsc:
-    lockPref("network.cookie.sameSite.laxByDefault", true);
-    lockPref("network.cookie.sameSite.laxByDefault.disabledHosts", "example.com,example.org,...");
 
     distribution\policies.json:
     "LegacySameSiteCookieBehaviorEnabled": false,

--- a/testcases/index.html
+++ b/testcases/index.html
@@ -62,10 +62,6 @@ a:visited {color:#00a;}
 
 <tr><th colspan="2">C</th></tr>
 <tr>
-  <th><a target='_blank' href="https://codepen.io/isystk/pen/VwLEzBJ">https://codepen.io/isystk/pen/VwLEzBJ</a></th>
-  <td>クロスサイトでのCookie送信のデモ (Privacy-64)</td>
-</tr>
-<tr>
   <th><a target='_blank' href="./cross-directory.html">cross-directory.html</a></th>
   <td>ローカルファイルからの他ディレクトリの参照の可否。手元に配置して使う (Security-14)</td>
 </tr>

--- a/verify/Privacy
+++ b/verify/Privacy
@@ -1851,65 +1851,22 @@ Privacy-64: SameSite指定が無いCookieの取り扱い
 
     :1: クロスサイトでの送信を常に許可 (既定）
 
-    - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル \
-      `{{special_profile_path}}` {%if Application_6_2_special_profile_actual_path %} \
-      （{{Application_6_2_special_profile_actual_path}}）{% endif %} \
-      を削除する。
-    - Firefoxを起動する。
-    - テストケースリストのリンクから \
-      `https://codepen.io/isystk/pen/VwLEzBJ` \
-      を開く。
-    - ページ下部のフレーム内の「タグによるアクセス」というラベル配下のリンクをクリックする。
-    - ページを再読み込みする。
-    - ページ下部のフレーム内の「タグによるアクセス」というラベル配下のリンクをもう1度クリックする。
-    - **確認**
-        - 遷移後のページの `noCokkie` と `noneCokkie` の両方に `◯` が表示されている。
+    ABOUT_POLICIES
+
+    - `LegacySameSiteCookieBehaviorEnabled` の値が存在しないか、`true` である。
 
     :2: クロスサイトでの送信をサブリソースに対しては禁止する
 
-    - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル \
-      `{{special_profile_path}}` {%if Application_6_2_special_profile_actual_path %} \
-      （{{Application_6_2_special_profile_actual_path}}）{% endif %} \
-      を削除する。
-    - Firefoxを起動する。
-    - テストケースリストのリンクから \
-      `https://codepen.io/isystk/pen/VwLEzBJ` \
-      を開く。
-    - ページ下部のフレーム内の「タグによるアクセス」というラベル配下のリンクをクリックする。
-    - ページを再読み込みする。
-    - ページ下部のフレーム内の「タグによるアクセス」というラベル配下のリンクをもう1度クリックする。
-    - **確認**
-        - 遷移後のページの `noCokkie` に `◯` が表示されていない。
+    ABOUT_POLICIES
+
+    - `LegacySameSiteCookieBehaviorEnabled` の値が `false` である。
 
     :3: クロスサイトでの送信をサブリソースに対しては禁止し、特定サイトでのみクロスサイトでの送信を常に許可
 
-    - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル \
-      `{{special_profile_path}}` {%if Application_6_2_special_profile_actual_path %} \
-      （{{Application_6_2_special_profile_actual_path}}）{% endif %} \
-      を削除する。
-    - Firefoxを起動する。
-    - テストケースリストのリンクから \
-      `https://codepen.io/isystk/pen/VwLEzBJ` \
-      を開く。
-    - ページ下部のフレーム内の「タグによるアクセス」というラベル配下のリンクをクリックする。
-    - ページを再読み込みする。
-    - ページ下部のフレーム内の「タグによるアクセス」というラベル配下のリンクをもう1度クリックする。
-    - **確認**
-        - 遷移後のページの `noCokkie` に `◯` が表示されていない。
-    - ポリシー設定を変更し `demo.isystk.com` をクロスサイトでのCookie送信許可サイトに加える。
-    - 今バージョンのメタインストーラで導入したFirefoxのユーザープロファイル \
-      `{{special_profile_path}}` {%if Application_6_2_special_profile_actual_path %} \
-      （{{Application_6_2_special_profile_actual_path}}）{% endif %} \
-      を削除する。
-    - Firefoxを起動する。
-    - テストケースリストのリンクから \
-      `https://codepen.io/isystk/pen/VwLEzBJ` \
-      を開く。
-    - ページ下部のフレーム内の「タグによるアクセス」というラベル配下のリンクをクリックする。
-    - ページを再読み込みする。
-    - ページ下部のフレーム内の「タグによるアクセス」というラベル配下のリンクをもう1度クリックする。
-    - **確認**
-        - 遷移後のページの `noCokkie` と `nonoeCokkie` の両方に `◯` が表示されている。
+    ABOUT_POLICIES
+
+    - `LegacySameSiteCookieBehaviorEnabled` の値が `false` である。
+    - `LegacySameSiteCookieBehaviorEnabledForDomainList` の値として許可サイトのホスト名が列挙されている。
 
 Privacy-65: 履歴データベースの有効化
 


### PR DESCRIPTION
Webサイトの閉鎖により検証手順が適用できなくなったため、設定は常にポリシーで行い、実際の動作ではなくポリシー設定が適用されているかどうかで判断するように手順を改めました。
（ポリシー設定は誤記があれば読み込まれないため、期待通り読み込まれていることを以てカスタマイズ反映に成功したものと見なせます。）